### PR TITLE
New `searchlight.sphere` functionality

### DIFF
--- a/code/utils/searchlight.py
+++ b/code/utils/searchlight.py
@@ -32,102 +32,106 @@ def inrange(arr, b, f, ind):
     return b, f
 
 def sphere(arr, c, r=1):
-    """Selecting adjacent voxels in 2d or 3d space
+    """Selecting adjacent voxels in 3d space, across time
     
     Parameters
     ----------
     arr: np.ndarray
-        2d or 3d input array
-    c: tuple (x, y[, z])
+        4d input array
+    c: tuple (x, y, z)
         The center voxel from which the volume is created
     r: int
-        The radius of the volume
+        The radius for the sphere
         
     Returns
     -------
     adjacent: np.ndarray
+        A sphere for every time time slice
 
     Examples
     --------
-    >>> X = np.arange(125).reshape(5, 5, 5)
-    >>> sphere(X, (2, 2, 2), 1)
-    array([[[31, 32, 33],
-            [36, 37, 38],
-            [41, 42, 43]],
+    >>> X = np.arange(54).reshape(3, 3, 3, 2)
+    >>> sphere(X, (1, 1, 1))
+    array([[[[ 0,  1],
+             [ 2,  3],
+             [ 4,  5]],
     <BLANKLINE>
-           [[56, 57, 58],
-            [61, 62, 63],
-            [66, 67, 68]],
-    <BLANKLINE>          
-           [[81, 82, 83],
-            [86, 87, 88],
-            [91, 92, 93]]])
-
-    >>> sphere(X, (2, 2, 2), 2)
-    array([[[  0,   1,   2,   3,   4],
-            [  5,   6,   7,   8,   9],
-            [ 10,  11,  12,  13,  14],
-            [ 15,  16,  17,  18,  19],
-            [ 20,  21,  22,  23,  24]],
+            [[ 6,  7],
+             [ 8,  9],
+             [10, 11]],
     <BLANKLINE>
-           [[ 25,  26,  27,  28,  29],
-            [ 30,  31,  32,  33,  34],
-            [ 35,  36,  37,  38,  39],
-            [ 40,  41,  42,  43,  44],
-            [ 45,  46,  47,  48,  49]],
+            [[12, 13],
+             [14, 15],
+             [16, 17]]],
     <BLANKLINE>
-           [[ 50,  51,  52,  53,  54],
-            [ 55,  56,  57,  58,  59],
-            [ 60,  61,  62,  63,  64],
-            [ 65,  66,  67,  68,  69],
-            [ 70,  71,  72,  73,  74]],
     <BLANKLINE>
-           [[ 75,  76,  77,  78,  79],
-            [ 80,  81,  82,  83,  84],
-            [ 85,  86,  87,  88,  89],
-            [ 90,  91,  92,  93,  94],
-            [ 95,  96,  97,  98,  99]],
+           [[[18, 19],
+             [20, 21],
+             [22, 23]],
     <BLANKLINE>
-           [[100, 101, 102, 103, 104],
-            [105, 106, 107, 108, 109],
-            [110, 111, 112, 113, 114],
-            [115, 116, 117, 118, 119],
-            [120, 121, 122, 123, 124]]])
-
-    >>> sphere(X, (0, 0, 0))
-    array([[[ 0,  1],
-            [ 5,  6]],
+            [[24, 25],
+             [26, 27],
+             [28, 29]],
     <BLANKLINE>
-           [[25, 26],
-            [30, 31]]])
-
-    >>> sphere(X, (1, 1, 0))
-    array([[[ 0,  1],
-            [ 5,  6],
-            [10, 11]],
+            [[30, 31],
+             [32, 33],
+             [34, 35]]],
     <BLANKLINE>
-           [[25, 26],
-            [30, 31],
-            [35, 36]],
     <BLANKLINE>
-           [[50, 51],
-            [55, 56],
-            [60, 61]]])
-
-    >>> sphere(X, (4, 2, 2))
-    array([[[ 81,  82,  83],
-            [ 86,  87,  88],
-            [ 91,  92,  93]],
+           [[[36, 37],
+             [38, 39],
+             [40, 41]],
     <BLANKLINE>
-           [[106, 107, 108],
-            [111, 112, 113],
-            [116, 117, 118]]])
-
-    >>> Y = np.arange(8).reshape(2, 4)
-    >>> sphere(Y, (0, 0))
-    array([[0, 1],
-           [4, 5]])
-
+            [[42, 43],
+             [44, 45],
+             [46, 47]],
+    <BLANKLINE>
+            [[48, 49],
+             [50, 51],
+             [52, 53]]]])
+    >>> Y = np.arange(5**4).reshape(5, 5, 5, 5)
+    >>> sphere(Y, (2, 2, 2))
+    array([[[[155, 156, 157, 158, 159],
+             [160, 161, 162, 163, 164],
+             [165, 166, 167, 168, 169]],
+    <BLANKLINE>
+            [[180, 181, 182, 183, 184],
+             [185, 186, 187, 188, 189],
+             [190, 191, 192, 193, 194]],
+    <BLANKLINE>
+            [[205, 206, 207, 208, 209],
+             [210, 211, 212, 213, 214],
+             [215, 216, 217, 218, 219]]],
+    <BLANKLINE>
+    <BLANKLINE>
+           [[[280, 281, 282, 283, 284],
+             [285, 286, 287, 288, 289],
+             [290, 291, 292, 293, 294]],
+    <BLANKLINE>
+            [[305, 306, 307, 308, 309],
+             [310, 311, 312, 313, 314],
+             [315, 316, 317, 318, 319]],
+    <BLANKLINE>
+            [[330, 331, 332, 333, 334],
+             [335, 336, 337, 338, 339],
+             [340, 341, 342, 343, 344]]],
+    <BLANKLINE>
+    <BLANKLINE>
+           [[[405, 406, 407, 408, 409],
+             [410, 411, 412, 413, 414],
+             [415, 416, 417, 418, 419]],
+    <BLANKLINE>
+            [[430, 431, 432, 433, 434],
+             [435, 436, 437, 438, 439],
+             [440, 441, 442, 443, 444]],
+    <BLANKLINE>
+            [[455, 456, 457, 458, 459],
+             [460, 461, 462, 463, 464],
+             [465, 466, 467, 468, 469]]]])
+    >>> (sphere(X, (1, 1, 1)) == X).all()
+    True
+    >>> (sphere(Y, (2, 2, 2), 2) == Y).all()
+    True
     """
     
     # checking type
@@ -136,10 +140,11 @@ def sphere(arr, c, r=1):
     assert isinstance(r, int), 'radius must be type int'
         
     # checking size
-    assert (1 < len(c) < 4), 'tuple length must 2 or 3'
-    assert len(c) == len(arr.shape), 'tuple length must equal array dim'
-    assert r < min(arr.shape), 'radius must be smaller than the smallest dim\
-        of the array'
+    assert len(arr.shape) == 4, 'array must be 4-dimensional'
+    assert len(c) == 3, 'tuple length must be 3'
+    assert len(c) == len(arr.shape)-1, 'tuple length must equal array dim'
+    assert r < min(arr.shape[:-1]), 'radius must be smaller than the '+\
+        'smallest dimension of the first three axes'
 
     # checking valid `c` for `arr`; IndexError raised if not
     arr[c]
@@ -147,28 +152,19 @@ def sphere(arr, c, r=1):
     b = lambda v, r: v - r
     f = lambda v, r: v + r
 
-    # center indices
-    if len(c) == 3:
-        x, y, z = c[0], c[1], c[2]
-        # zb, zf = z - r, z + r
-        zb, zf = b(z, r), f(z, r)
-    elif len(c) == 2:
-        x, y = c[0], c[1] 
+    # indices
+    x, y, z = c[0], c[1], c[2]
 
     # reach
     xb, xf = b(x, r), f(x, r)
     yb, yf = b(y, r), f(y, r)
+    zb, zf = b(z, r), f(z, r)
 
     # checking within dimensions
-    if len(c) == 3:
-        xb, xf = inrange(arr, xb, xf, 0)
-        yb, yf = inrange(arr, yb, yf, 1)
-        zb, zf = inrange(arr, zb, zf, 2)
-        return arr[xb:xf+1, yb:yf+1, zb:zf+1]
-    elif len(c) == 2:
-        xb, xf = inrange(arr, xb, xf, 0)
-        yb, yf = inrange(arr, yb, yf, 1)
-        return arr[xb:xf+1, yb:yf+1]
+    xb, xf = inrange(arr, xb, xf, 0)
+    yb, yf = inrange(arr, yb, yf, 1)
+    zb, zf = inrange(arr, zb, zf, 2)
+    return arr[xb:xf+1, yb:yf+1, zb:zf+1]
 
 def nonzero_indices(arr):
     """Get the 3d indices for `arr` (4d) where the value is nonzero


### PR DESCRIPTION
Accepts only a 4d array. Still returns the volumes given a center `c` and
radius `r`, but does so across all time slices. For an array of shape
(5, 5, 5, 5), for example, `sphere(X, (2, 2, 2))` returns an array of size
(3, 3, 3, 5).